### PR TITLE
Update NuclearRockets install folder

### DIFF
--- a/USI-NuclearRockets.netkan
+++ b/USI-NuclearRockets.netkan
@@ -26,7 +26,7 @@
 	],
 	"install": [
 		{
-			"find"	   : "UmbraSpaceIndustries/Orion",
+			"find"	   : "UmbraSpaceIndustries/NuclearRockets",
 			"install_to" : "GameData/UmbraSpaceIndustries"
 		}
 	],


### PR DESCRIPTION
## Problem

The latest release of NuclearRockets has an inflation error that is preventing it from being added to CKAN:

![image](https://user-images.githubusercontent.com/1559108/171032401-1f850820-16a5-4ba0-bb30-ce9b5b8561fd.png)

## Cause

The mod's folder name was changed from `Orion` to `NuclearRockets`, and the metanetkan in this repo still has the old name.

## Changes

Now the install stanza is updated to use the new folder name.

Tagging @BobPalmer and @tjdeckard to make sure GitHub sends notifications.
